### PR TITLE
fix a Message.signedWithCerts property content

### DIFF
--- a/lib/models/Message.js
+++ b/lib/models/Message.js
@@ -470,8 +470,12 @@ class Message {
     const tokens = [this.pattrs.contentTimeStamp, this.puattrs.timeStampToken]
       .filter(msg => msg)
       .map(msg => msg.signedWithCerts);
-    return [this.signerRDN].concat(...tokens);
-  }
+
+      if (this.signerRDN.serialNumber) {
+        return [this.signerRDN].concat(...tokens);
+      }
+      return tokens;
+    }
 
   get signerRDN() {
     const [


### PR DESCRIPTION
Доброго здоров'я.
Маю один p7s файл і щось не перевіряється підпис, помилки не виводиться, в ньому коли використовую ваш github.com/dstucrypt/agent.
Перевіряю в режимі --verify --ocsp lax. З'ясував що саме перевірка --ocsp викликає помилку, яка є коли в об'єкт Message, в поле signedWithCerts, що є масивом, записувалось три об'єкта що представляють сертифікати, які читаються з цього p7s файла. Першій 'сертифікат' був з полем serialNumber, інші два об'єкта були тільки з полем keyId. Я пошукав що там в поле keyId зачиталось з p7s файла. 
Використав http://lapo.it/asn1js щоб подивитись байти з keyId у файлі p7s. Маю картинку де видно ці байти в файлі і які ідентифікатори asn1 їм відповідають. Я так зробив висновок що то пакет asn1.js помилково розбирає p7s.
В цьому PR я пропоную корекцію к полю signedWithCerts що
б взагалі відсікати такі прочитані `сертифікати` в яких немає поля serialNumber.  Тести проходять ті що в вас є в jkurwa. 
Але я _не впевнений_ що зроблено вірно для всіх, але мою помилку виправило і також коректно перевіряє p7s файли ті що раніше і так перевірялись.  