### PR TITLE
fix: ReferenceError in Priv.from_asn1 for named-curve keysFix named curve from asn1

### DIFF
--- a/lib/models/Priv.js
+++ b/lib/models/Priv.js
@@ -84,7 +84,7 @@ function from_asn1(data, return_store) {
   const params = priv.priv0.p.p;
   curve =
     params.type === "id"
-      ? jk.std_curve(params.value)
+      ? stdCurve(params.value)
       : curve_params(params.value);
   key0 = curve.pkey(util.BIG_LE(priv.param_d), "buf32");
   key0.sbox = priv.priv0.p.sbox;

--- a/test/test-priv-named-curve.js
+++ b/test/test-priv-named-curve.js
@@ -1,0 +1,71 @@
+import { describe, it } from "vitest";
+import assert from "assert";
+
+import * as jk from "../lib/index.js";
+
+/* Minimal DER encoding helpers to build a PKCS#8 DSTU key
+ * that references the curve by OID (named curve) instead of
+ * spelling out explicit curve parameters. Keys issued by bank
+ * CAs (e.g. monobank / Universal Bank .pfx containers) use
+ * this form, while the fixture keys in test/data carry
+ * explicit parameters — which is why the broken branch in
+ * Priv.from_asn1 (`jk.std_curve` with no `jk` in scope,
+ * ReferenceError "jk is not defined") went unnoticed. */
+const lenBytes = len => {
+  if (len < 0x80) return Buffer.from([len]);
+  const b = [];
+  let v = len;
+  while (v > 0) {
+    b.unshift(v & 0xff);
+    v >>= 8;
+  }
+  return Buffer.from([0x80 | b.length, ...b]);
+};
+const tlv = (tag, content) =>
+  Buffer.concat([Buffer.from([tag]), lenBytes(content.length), content]);
+const seq = (...parts) => tlv(0x30, Buffer.concat(parts));
+const octstr = b => tlv(0x04, b);
+const int0 = tlv(0x02, Buffer.from([0]));
+const oid = dotted => {
+  const p = dotted.split(".").map(Number);
+  const bytes = [p[0] * 40 + p[1]];
+  for (const arc of p.slice(2)) {
+    const chunk = [];
+    let v = arc;
+    do {
+      chunk.unshift(v & 0x7f);
+      v >>= 7;
+    } while (v > 0);
+    for (let i = 0; i < chunk.length - 1; i++) chunk[i] |= 0x80;
+    bytes.push(...chunk);
+  }
+  return tlv(0x06, Buffer.from(bytes));
+};
+
+const OID_DSTU4145_LE = "1.2.804.2.1.1.1.1.3.1.1";
+const OID_CURVE_PB257 = "1.2.804.2.1.1.1.1.3.1.1.2.6";
+
+function namedCurveKey() {
+  // PKCS#8-style DstuPrivkey:
+  // SEQ { INTEGER 0,
+  //       SEQ { OID dstu4145le, SEQ { Curve ::= OID (named) } },
+  //       OCTET STRING param_d (LE) }
+  const d = Buffer.alloc(32, 0x42);
+  d[31] = 0x01; // keep d well below the group order
+  return seq(int0, seq(oid(OID_DSTU4145_LE), seq(oid(OID_CURVE_PB257))), octstr(d));
+}
+
+describe("Priv.from_asn1 with named curve", () => {
+  it("parses a key that references the curve by OID", () => {
+    const priv = jk.Priv.from_asn1(namedCurveKey());
+    assert.equal(priv.type, "Priv");
+    assert.ok(priv.curve.equals(jk.std_curve("DSTU_PB_257")));
+  });
+
+  it("returns a store when asked to", () => {
+    const store = jk.Priv.from_asn1(namedCurveKey(), true);
+    assert.equal(store.format, "privkeys");
+    assert.equal(store.keys.length, 1);
+    assert.equal(store.keys[0].type, "Priv");
+  });
+});


### PR DESCRIPTION
```markdown
## Problem

`Priv.from_asn1` throws `ReferenceError: jk is not defined` for any
private key that references its curve **by OID** (named curve) instead
of carrying explicit curve parameters:

```js
// lib/models/Priv.js
curve =
  params.type === "id"
    ? jk.std_curve(params.value)   // <-- no `jk` binding in this module
    : curve_params(params.value);
```

The module imports `std_curve as stdCurve`, but this branch refers to a
non-existent `jk` namespace. The same code is baked into the published
`dist/index.cjs` / `dist/index.mjs` bundles.

## Impact

Keys issued by bank CAs commonly use the named-curve form. In
particular, PKCS#12 containers issued by the monobank / Universal Bank
CA (`ca.monobank.ua`) contain DSTU-4145 keys referencing `DSTU_PB_257`
by OID — every such key fails to load with "jk is not defined"
(surfacing as "Cant load key from store" through `util/load.js`).
Confirmed on a real monobank-issued key.

The fixture keys under `test/data` all carry explicit curve parameters,
so the existing suite never exercises this branch.

## Fix

Use the imported `stdCurve` binding (one line).

## Test

Added `test/test-priv-named-curve.js`, which builds a PKCS#8 DSTU key
referencing `DSTU_PB_257` by OID and parses it both as a bare key and
as a store:

- without the fix both cases fail with `ReferenceError: jk is not defined`;
- with the fix they pass, and the full suite stays green (156 passed).
```

