### PR TITLE
test: cover the CA-shaped OID-curve key, and stop guessStore discarding the real error

### DIFF
--- a/lib/models/Priv.js
+++ b/lib/models/Priv.js
@@ -405,11 +405,21 @@ function parseWithFn(data, parserFns) {
 }
 
 function guessStore(data) {
+  let privErr;
   try {
     return Priv.from_asn1(data, true);
-  } catch (e) {}
+  } catch (e) {
+    privErr = e;
+  }
 
-  return { format: "certbags", certs: pfx.certbags_from_asn1(data) };
+  try {
+    return { format: "certbags", certs: pfx.certbags_from_asn1(data) };
+  } catch (certErr) {
+    throw new Error(
+      `Cant parse store as private key (${privErr.message}) ` +
+        `or as cert store (${certErr.message})`
+    );
+  }
 }
 
 export default Priv;

--- a/test/test-guess-store.js
+++ b/test/test-guess-store.js
@@ -1,0 +1,24 @@
+import { describe, it } from "vitest";
+import assert from "node:assert";
+
+import * as jk from "../lib/index.js";
+
+/* Priv.from_protected() (no password) runs each candidate buffer through
+ * guessStore(), which tries Priv.from_asn1() first and, on any failure,
+ * silently falls through to the cert-bag parser. When the input is neither
+ * a valid private key store nor a valid cert bag, callers used to see only
+ * the cert-bag parser's unrelated failure ("Failed to match tag: seq" and
+ * similar) with the original, often more useful, from_asn1 error discarded
+ * -- which is exactly what hid the `jk is not defined` ReferenceError
+ * behind a confusing asn1 tag-mismatch error before it was diagnosed. */
+describe("guessStore diagnostics", () => {
+  it("surfaces the original from_asn1 failure when no candidate parses", () => {
+    const garbage = Buffer.from([0x30, 0x03, 0x01, 0x02, 0x03]);
+
+    assert.throws(
+      () => jk.Priv.from_protected(garbage),
+      /version/,
+      "expected the private-key parse error to be part of the thrown message"
+    );
+  });
+});

--- a/test/test-priv-named-curve.js
+++ b/test/test-priv-named-curve.js
@@ -55,6 +55,18 @@ function namedCurveKey() {
   return seq(int0, seq(oid(OID_DSTU4145_LE), seq(oid(OID_CURVE_PB257))), octstr(d));
 }
 
+function namedCurveKeyWithDkeKey() {
+  // Same shape as issued by CA software in the wild (e.g. monobank / ДПС
+  // КЕП containers): the named-curve OID is accompanied by an extra
+  // 64-byte octet string (labelled ДКЕ by such tooling) alongside it,
+  // instead of being the sole element of the curve choice. 138 bytes total.
+  const dke = Buffer.alloc(64, 0x11);
+  const params = seq(oid(OID_CURVE_PB257), octstr(dke));
+  const algorithm = seq(oid(OID_DSTU4145_LE), params);
+  const d = Buffer.alloc(32, 0x22);
+  return seq(int0, algorithm, octstr(d));
+}
+
 describe("Priv.from_asn1 with named curve", () => {
   it("parses a key that references the curve by OID", () => {
     const priv = jk.Priv.from_asn1(namedCurveKey());
@@ -67,5 +79,14 @@ describe("Priv.from_asn1 with named curve", () => {
     assert.equal(store.format, "privkeys");
     assert.equal(store.keys.length, 1);
     assert.equal(store.keys[0].type, "Priv");
+  });
+
+  it("parses a CA-shaped named-curve key carrying a DKE alongside the OID", () => {
+    const key = namedCurveKeyWithDkeKey();
+    assert.equal(key.length, 138);
+
+    const priv = jk.Priv.from_asn1(key);
+    assert.equal(priv.type, "Priv");
+    assert.ok(priv.curve.equals(jk.std_curve("DSTU_PB_257")));
   });
 });


### PR DESCRIPTION
Follow-up to #64. The `ReferenceError` itself is already fixed on `master` by #58 — this covers the two things that survive it.

**1. A regression fixture in the shape CAs actually emit.** #58's test covers a named curve; this adds the variant that failed for us in the wild — the curve OID *plus* the accompanying 64-byte ДКЕ octet string, 138 bytes total. It is built by hand, so it needs no key material.

**2. `guessStore` no longer discards the private-key parse error.** It ran `try { Priv.from_asn1(data, true) } catch (e) {}` and then fell through to the cert-bag parse, so when both failed the caller only ever saw the *second* error. That is what made #64 expensive: the visible message (`length octect is too long`, `Failed to match tag: "seqof"`) described an unrelated parse, and we built and discarded six hypotheses on it before finding the real cause. The first error is now retained and both are reported when everything fails.

`npm test` passes (161 tests). `npm run build` succeeds.
