### PR TITLE
fix: Box.findCertsCmp() can never succeed — undeclared `certificates`, then a swallowed error

### DIFF
--- a/lib/app/ctx.js
+++ b/lib/app/ctx.js
@@ -104,11 +104,31 @@ class Box {
     return numberAdded;
   }
 
+  // Fetches missing certificates for this Box's keys from a CA's CMP
+  // service.
+  //
+  // The first-class, recommended way to call this is with `urlsHint`: an
+  // explicit list of CMP endpoint URLs for the CA(s) to query, e.g. the
+  // "cmp" address from a trusted CA registry such as
+  // https://iit.com.ua/download/productfiles/CAs.json. Passing it bypasses
+  // guessing entirely.
+  //
+  // When `urlsHint` is omitted, this falls back to a heuristic: it takes
+  // the OCSP URLs advertised in the loaded CA certificates' AIA extension
+  // and guesses a CMP URL by substituting "ocsp" -> "cmp" in them. This is
+  // only a guess, not a protocol guarantee, and it is known to be wrong for
+  // at least some CAs (e.g. it derives "ca.monobank.ua/services/cmp/dstu/"
+  // where the real endpoint is "ca.monobank.ua/services/cmp/", and
+  // "cmp.e-life.com.ua" where the real endpoint is
+  // "cmp.e-life.com.ua/api/PKI/CMP") and it produces no URL at all for CAs
+  // whose OCSP URL doesn't contain the substring "ocsp". Prefer passing
+  // `urlsHint` whenever the caller can obtain the real CMP address.
   async findCertsCmp(urlsHint) {
     let steps = [];
     if (urlsHint && urlsHint.length) {
       steps = [urlsHint];
     } else {
+      // Heuristic fallback only - see the function-level comment above.
       steps = this.getUniqueOCSPUrls().map(url => [url.replace(/ocsp/, "cmp")]);
     }
     const loadOne = url => {

--- a/lib/services/cmp.js
+++ b/lib/services/cmp.js
@@ -29,12 +29,19 @@ function unpack(resp) {
   }
   var result = rmsg.info.readInt32LE(4);
   if (result !== 1) {
-    return null;
+    // A well-formed response that isn't a success (e.g. status 9 - "no
+    // certificate for this key identifier") is not a parse failure: throw
+    // a tagged error so lookup() can tell it apart from a response that
+    // could not be parsed at all.
+    var statusError = new Error("cmp: server returned status " + result);
+    statusError.cmpStatus = result;
+    throw statusError;
   }
   rmsg = new Message(rmsg.info.slice(8));
-  return (certificates = rmsg.info.certificate.map(function(certData) {
+  var certificates = rmsg.info.certificate.map(function(certData) {
     return new Certificate(certData);
-  }));
+  });
+  return certificates;
 }
 
 function lookup(keyids, url, query) {
@@ -51,7 +58,13 @@ function lookup(keyids, url, query) {
       try {
         certificates = unpack(response);
       } catch (e) {
-        console.error("e", e);
+        // Surface the real error instead of swallowing it: a status-9
+        // ("no certificate for this key identifier") response is a clean,
+        // distinguishable not-found rather than a parse failure. Anything
+        // else (including bugs in unpack() itself) keeps the pre-existing
+        // "data" reason, but now carries the original error too.
+        const reason = e && e.cmpStatus === 9 ? "not-found" : "data";
+        return reject({ reason, status: e && e.cmpStatus, error: e });
       }
       if (!certificates) {
         return reject({ reason: "data" });

--- a/lib/services/cmp.js
+++ b/lib/services/cmp.js
@@ -27,21 +27,19 @@ function unpack(resp) {
   if (!rmsg.info) {
     return null;
   }
-  var result = rmsg.info.readInt32LE(4);
-  if (result !== 1) {
+  var status = rmsg.info.readInt32LE(4);
+  if (status !== 1) {
     // A well-formed response that isn't a success (e.g. status 9 - "no
-    // certificate for this key identifier") is not a parse failure: throw
-    // a tagged error so lookup() can tell it apart from a response that
-    // could not be parsed at all.
-    var statusError = new Error("cmp: server returned status " + result);
-    statusError.cmpStatus = result;
-    throw statusError;
+    // certificate for this key identifier") is not a parse failure, so it
+    // reports the status instead. `null` stays reserved for "could not be
+    // parsed at all", which is what lets lookup() tell the two apart.
+    return { status: status, certificates: null };
   }
   rmsg = new Message(rmsg.info.slice(8));
   var certificates = rmsg.info.certificate.map(function(certData) {
     return new Certificate(certData);
   });
-  return certificates;
+  return { status: status, certificates: certificates };
 }
 
 function lookup(keyids, url, query) {
@@ -54,22 +52,27 @@ function lookup(keyids, url, query) {
       if (status !== 200) {
         return reject({ reason: "http", status });
       }
-      let certificates;
+      let parsed;
       try {
-        certificates = unpack(response);
+        parsed = unpack(response);
       } catch (e) {
-        // Surface the real error instead of swallowing it: a status-9
-        // ("no certificate for this key identifier") response is a clean,
-        // distinguishable not-found rather than a parse failure. Anything
-        // else (including bugs in unpack() itself) keeps the pre-existing
-        // "data" reason, but now carries the original error too.
-        const reason = e && e.cmpStatus === 9 ? "not-found" : "data";
-        return reject({ reason, status: e && e.cmpStatus, error: e });
+        // Not a protocol outcome - unpack() reports those by return value.
+        // Reaching here means unpack() itself threw, so surface the error
+        // rather than swallowing it behind a bare "data" as before.
+        return reject({ reason: "data", error: e });
       }
-      if (!certificates) {
+      if (!parsed) {
         return reject({ reason: "data" });
       }
-      resolve(certificates);
+      if (!parsed.certificates) {
+        // Status 9 is "no certificate for this key identifier" - a clean
+        // not-found. Every other non-success status keeps the pre-existing
+        // "data" reason, so callers checking for it are unaffected and
+        // simply gain `status`.
+        const reason = parsed.status === 9 ? "not-found" : "data";
+        return reject({ reason, status: parsed.status });
+      }
+      resolve(parsed.certificates);
     });
   });
 }

--- a/lib/services/cmp.js
+++ b/lib/services/cmp.js
@@ -27,7 +27,7 @@ function unpack(resp) {
   if (!rmsg.info) {
     return null;
   }
-  var status = rmsg.info.readInt32LE(4);
+  const status = rmsg.info.readInt32LE(4);
   if (status !== 1) {
     // A well-formed response that isn't a success (e.g. status 9 - "no
     // certificate for this key identifier") is not a parse failure, so it
@@ -36,7 +36,7 @@ function unpack(resp) {
     return { status: status, certificates: null };
   }
   rmsg = new Message(rmsg.info.slice(8));
-  var certificates = rmsg.info.certificate.map(function(certData) {
+  const certificates = rmsg.info.certificate.map(function(certData) {
     return new Certificate(certData);
   });
   return { status: status, certificates: certificates };

--- a/test/test-cmp.js
+++ b/test/test-cmp.js
@@ -1,0 +1,119 @@
+import { describe, it } from "vitest";
+import assert from "assert";
+import * as jk from "../lib/index.js";
+import * as cmpService from "../lib/services/cmp.js";
+import { loadAsset } from "./utils.js";
+
+const { ContentInfo } = jk.dstszi2010;
+
+// Builds the outer CMS `data` ContentInfo envelope that the CMP service
+// wraps every reply in. `content` is the raw octet-string payload: 8 bytes
+// (opcode + status) on failure, or that header followed by a nested
+// message on success.
+function buildResponse(content) {
+  return ContentInfo.encode({ contentType: "data", content }, "der");
+}
+
+function buildStatusResponse(status) {
+  const header = Buffer.alloc(8);
+  header.writeInt32LE(0x0d, 0); // echoes the request opcode
+  header.writeInt32LE(status, 4);
+  return buildResponse(header);
+}
+
+function buildSuccessResponse(certs) {
+  const header = Buffer.alloc(8);
+  header.writeInt32LE(0x0d, 0);
+  header.writeInt32LE(1, 4); // 1 == success
+
+  // The nested message is itself a CMS SignedData whose only field cmp.js
+  // reads is `certificate`; version/digestAlgorithms/signerInfos are left
+  // empty since unpack() never looks at them.
+  const nested = ContentInfo.encode(
+    {
+      contentType: "signedData",
+      content: {
+        version: 1,
+        digestAlgorithms: [],
+        contentInfo: { contentType: "data" },
+        certificate: certs.map(cert => cert.ob),
+        signerInfos: []
+      }
+    },
+    "der"
+  );
+
+  return buildResponse(Buffer.concat([header, nested]));
+}
+
+// A `query` stub matching the (method, url, headers, payload, cb) signature
+// `lookup()` calls, so tests never touch the network.
+function stubQuery(response, status = 200) {
+  return (method, url, headers, payload, cb) => cb(response, status);
+}
+
+describe("cmp service", () => {
+  const cert = jk.Certificate.from_asn1(loadAsset("SELF_SIGNED1.cer"));
+  const keyids = [Buffer.alloc(32, 1)];
+
+  it("unpacks a successful response into certificates", async () => {
+    // Regression test for the undeclared `certificates` assignment in
+    // unpack(): under strict mode (as in the built ESM output) that line
+    // throws `ReferenceError: certificates is not defined` on exactly this
+    // - the success - path, so this case used to be the one guaranteed to
+    // fail.
+    const response = buildSuccessResponse([cert]);
+
+    const certificates = await cmpService.lookup(
+      keyids,
+      "http://cmp.example.test/",
+      stubQuery(response)
+    );
+
+    assert.equal(certificates.length, 1);
+    assert.ok(certificates[0] instanceof jk.Certificate);
+    assert.equal(certificates[0].rdnSerial(), cert.rdnSerial());
+  });
+
+  it("rejects a status-9 response as a distinguishable not-found, not a parse error", async () => {
+    const response = buildStatusResponse(9);
+
+    await assert.rejects(
+      () => cmpService.lookup(keyids, "http://cmp.example.test/", stubQuery(response)),
+      err => {
+        assert.equal(err.status, 9);
+        assert.equal(err.reason, "not-found");
+        assert.notEqual(err.reason, "data");
+        return true;
+      }
+    );
+  });
+
+  it("still rejects with reason 'data' (and the causing error attached) when the response cannot be parsed at all", async () => {
+    const garbage = Buffer.from([0xff, 0x00, 0x01, 0x02]);
+
+    await assert.rejects(
+      () => cmpService.lookup(keyids, "http://cmp.example.test/", stubQuery(garbage)),
+      err => {
+        assert.equal(err.reason, "data");
+        return true;
+      }
+    );
+  });
+
+  it("rejects with reason 'http' on a non-200 response, unchanged", async () => {
+    await assert.rejects(
+      () =>
+        cmpService.lookup(
+          keyids,
+          "http://cmp.example.test/",
+          stubQuery(Buffer.alloc(0), 404)
+        ),
+      err => {
+        assert.equal(err.reason, "http");
+        assert.equal(err.status, 404);
+        return true;
+      }
+    );
+  });
+});


### PR DESCRIPTION
Fixes #65. Both defects are present on current `master`.

**1. `unpack()` assigned to an undeclared `certificates`** (`lib/services/cmp.js:35`). `dist/index.mjs` is an ES module and therefore strict, so this threw `ReferenceError` **on the success path only** — every failure path returns earlier and never reaches the line. `dist/index.cjs` carries no `"use strict"`, so there the same statement quietly created a global and appeared to work. Net effect: `require()` consumers were fine, `import` consumers (anything bundled for a browser) got nothing back from a successful fetch.

**2. The error was then swallowed.** `lookup` caught it, `console.error`'d, and rejected with a generic `{reason: "data"}`, so a caller could not distinguish a successful-but-crashing parse from a malformed response.

`unpack()` now reports a non-success status by return value rather than by throwing: `{ status, certificates }`, with `certificates: null` when the envelope parses but the status is not `1`. `null` keeps its single meaning of "could not be parsed at all", which is what lets `lookup()` tell the two apart. `unpack()` is module-private (only `lookup` is exported), so the changed shape reaches no consumer.

`lookup()` rejects with `{ reason, status }`, using `reason: "not-found"` for status `9` and keeping `"data"` for everything else — so existing consumers checking `err.reason === "data"` are unaffected and simply gain `status`. Its `try/catch` remains, but now only as a net for `unpack()` genuinely throwing (a bug, not a protocol outcome), and it still attaches that error instead of swallowing it.

**3. Endpoint derivation** is documented rather than changed. `findCertsCmp`'s `urlsHint` is now described as the first-class path, and the AIA `ocsp`→`cmp` substitution is marked as a heuristic that is known-wrong for some CAs — checked against the 33 entries of the IIT registry, it produces the wrong URL for 2 and nothing for 3 more. No registry fetch was added; that is a consumer's decision.

Four new tests in `test/test-cmp.js`, all with a stubbed transport and no network. The success-path test fails on unpatched `master` with `ReferenceError: certificates is not defined`. `npm test` passes (163 tests); `npm run build` succeeds.

